### PR TITLE
zemax/zmxread: fix errors w/non-pathlib filenames

### DIFF
--- a/src/rayoptics/gui/appcmds.py
+++ b/src/rayoptics/gui/appcmds.py
@@ -11,6 +11,7 @@
 import os.path
 import json_tricks
 import math
+import pathlib
 
 from opticalglass import glassmap as gm
 from opticalglass import glassfactory as gfact
@@ -66,7 +67,8 @@ def open_model(file_name, info=False, **kwargs):
     Returns:
         if successful, an OpticalModel instance, otherwise, None
     """
-    file_extension = os.path.splitext(file_name)[1].lower()
+    file_name = pathlib.Path(file_name)
+    file_extension = file_name.suffix.lower()
     opm = None
     if file_extension == '.seq':
         opm, import_info = cvp.read_lens(file_name, **kwargs)

--- a/src/rayoptics/zemax/zmxread.py
+++ b/src/rayoptics/zemax/zmxread.py
@@ -212,8 +212,8 @@ def post_process_input(opt_model, filename, **kwargs):
     sm.gaps.pop()
 
     if opt_model.system_spec.title == '' and filename is not None:
-        fname_full = str(filename)
-        _, cat, fname = fname_full.rsplit('/', 2)
+        fname_full = filename.resolve()
+        cat, fname = fname_full.parts[-2:]
         title = "{:s}: {:s}".format(cat, fname)
         opt_model.system_spec.title = title
 


### PR DESCRIPTION
This file was written assuming the filepaths are all pathlib.Path's but
the docs don't make this clear and being able to path plain old string
to these functions would be good.

Explicitly convert filenames to pathlib.Path before calling pathlib
functions on them.

Additionally resolve and make the path absolute when creating titles
based on the filename. This prevents errors when the path is relative
with only one component.