### PR TITLE
Fix Zemax / Code V file import from current working directory

### DIFF
--- a/src/rayoptics/gui/appcmds.py
+++ b/src/rayoptics/gui/appcmds.py
@@ -83,7 +83,7 @@ def open_model(file_url, info=False, post_process_imports=True, **kwargs):
         opm = open_roa(file_url_pth, **kwargs)
     else:
         # if we're importing another program's file, collect import info
-        if file_url_pth.parts[1] == 'www.photonstophotos.net':
+        if len(file_url_pth.parts) > 0 and file_url_pth.parts[1] == 'www.photonstophotos.net':
             opm, import_info = obench.read_obench_url(file_url, **kwargs)
         elif file_extension == '.seq':
             opm, import_info = cmdproc.read_lens(file_url_pth, **kwargs)


### PR DESCRIPTION
This PR fixes Zemax / Code V file import from current working directory.

Previously, trying to import these files from the current working directory would result in an index out of range error.