### PR TITLE
Use local loggers to make messages externally filterable

### DIFF
--- a/src/rayoptics/codev/cmdproc.py
+++ b/src/rayoptics/codev/cmdproc.py
@@ -26,6 +26,12 @@ from opticalglass import util
 from opticalglass import opticalmedium as om
 from opticalglass import modelglass as mg
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+_fh = logging.FileHandler('cv_cmd_proc.log', mode='w')
+_fh.setLevel(logging.DEBUG)
+logger.addHandler(_fh)
+
 _tla = tla.MapTLA()
 
 # Support for CODE V private catalog materials.
@@ -60,9 +66,6 @@ def read_lens(filename, **kwargs):
     import rayoptics.optical.opticalmodel as opticalmodel
     global _glass_handler, _track_contents
     global _reading_private_catalog
-    logging.basicConfig(filename='cv_cmd_proc.log',
-                        filemode='w',
-                        level=logging.DEBUG)
     _reading_private_catalog = False
     _track_contents = util.Counter()
     opt_model = opticalmodel.OpticalModel(do_init=False)
@@ -74,7 +77,7 @@ def read_lens(filename, **kwargs):
             eval_str = cmd_fct + '(opt_model, tla, qlist, dlist)'
             eval(eval_str)
         else:
-            logging.info('Line %d: Command %s not supported', i+1, c[0])
+            logger.info('Line %d: Command %s not supported', i+1, c[0])
 
     post_process_input(opt_model, filename, **kwargs)
     _glass_handler.save_replacements()
@@ -145,7 +148,7 @@ def process_command(cmd):
 
 
 def log_cmd(label, tla, qlist, dlist):
-    logging.debug("%s: %s %s %s", label, tla, str(qlist), str(dlist))
+    logger.debug("%s: %s %s %s", label, tla, str(qlist), str(dlist))
 
 
 def post_process_input(opt_model, filename, **kwargs):
@@ -207,7 +210,7 @@ def pupil_spec_data(optm, tla, qlist, dlist):
         pupil.key = 'aperture', 'image', 'f/#'
 
     pupil.value = dlist[0]
-    logging.debug("pupil_spec_data: %s %f", tla, dlist[0])
+    logger.debug("pupil_spec_data: %s %f", tla, dlist[0])
 
 
 def field_spec_data(optm, tla, qlist, dlist):

--- a/src/rayoptics/gui/appcmds.py
+++ b/src/rayoptics/gui/appcmds.py
@@ -57,6 +57,8 @@ from rayoptics.qtgui.plotview import (create_plot_scale_panel,
                                       create_diagram_layers_groupbox,
                                       create_2d_figure_toolbar)
 
+logger = logging.getLogger(__name__)
+
 
 def open_model(file_url, info=False, post_process_imports=True, **kwargs):
     """ open a file or url and populate an optical model with the data
@@ -322,7 +324,7 @@ def create_parax_design_commands(fig):
     try:
         rayoptics_pos = pth.parts.index('rayoptics')
     except ValueError:
-        logging.debug("Can't find rayoptics: path is %s", pth)
+        logger.debug("Can't find rayoptics: path is %s", pth)
     else:
         # models_dir = rayoptics/models
         models_dir = pathlib.Path(*pth.parts[:rayoptics_pos+1]) / 'models'

--- a/src/rayoptics/gui/appmanager.py
+++ b/src/rayoptics/gui/appmanager.py
@@ -11,6 +11,8 @@ import logging
 
 from collections import namedtuple
 
+logger = logging.getLogger(__name__)
+
 ModelInfo = namedtuple('ModelInfo', ['model', 'fct', 'args', 'kwargs'])
 ModelInfo.__new__.__defaults__ = (None, (), {})
 ModelInfo.model.__doc__ = "object associated with view update function"
@@ -113,7 +115,7 @@ class AppManager:
         Args:
             view: view being closed by user
         """
-        logging.debug(f'AppManager.delete_view: {view.windowTitle()}')
+        logger.debug(f'AppManager.delete_view: {view.windowTitle()}')
         self.view_dict.pop(view, None)
 
     def close_model(self, view_close_fct=None):
@@ -178,18 +180,18 @@ class AppManager:
             try:
                 info = self.view_dict[view]
             except KeyError:
-                logging.debug('view "%s" not in view_dict',
+                logger.debug('view "%s" not in view_dict',
                               view.windowTitle())
             else:
                 mi = info[1]
                 model = mi.model
                 if model:
-                    logging.debug("on_view_activated: %s, %s" %
+                    logger.debug("on_view_activated: %s, %s" %
                                   (model.name(), view.windowTitle()))
                 if model and model != self.model:
                     self.model = model
                     self.refresh_views()
-                    logging.debug("switch model to", model.name())
+                    logger.debug("switch model to", model.name())
 
     def sync_light_or_dark(self, is_dark):
         """ Tells views to update to a light or dark color scheme """

--- a/src/rayoptics/mpl/interactivefigure.py
+++ b/src/rayoptics/mpl/interactivefigure.py
@@ -23,6 +23,7 @@ from rayoptics.mpl.styledfigure import StyledFigure
 from rayoptics.gui import util
 from rayoptics.util import rgb2mpl
 
+logger = logging.getLogger(__name__)
 
 SelectInfo = namedtuple('SelectInfo', ['artist', 'info'])
 SelectInfo.artist.__doc__ = "the artist"
@@ -484,12 +485,12 @@ class InteractiveFigure(StyledFigure):
 
                     artists.append(SelectInfo(artist, info))
                     if 'ind' in info:
-                        logging.debug("on motion, artist {}: {}.{}, z={}, "
+                        logger.debug("on motion, artist {}: {}.{}, z={}, "
                                       "hits={}".format(len(artists),
                                       shape.get_label(), handle,
                                       artist.get_zorder(), info['ind']))
                     else:
-                        logging.debug("on motion, artist {}: {}.{}, z={}"
+                        logger.debug("on motion, artist {}: {}.{}, z={}"
                                       .format(len(artists), shape.get_label(),
                                               handle, artist.get_zorder()))
 
@@ -545,22 +546,22 @@ class InteractiveFigure(StyledFigure):
                     next_hilited.artist.figure.canvas.draw()
                 self.hilited = next_hilited
                 if next_hilited is None:
-                    logging.debug("hilite_change: no object found")
+                    logger.debug("hilite_change: no object found")
                 else:
                     shape, handle = self.hilited.artist.shape
-                    logging.debug("hilite_change: %s %s %d",
+                    logger.debug("hilite_change: %s %s %d",
                                   shape.get_label(), handle,
                                   self.hilited.artist.get_zorder())
         else:
             # display_artist_and_event('on_drag', event, self.selected.artist)
             self.do_action(event, self.selected, 'drag')
             shape, handle = self.selected.artist.shape
-            logging.debug("on_drag: %s %s %d", shape.get_label(), handle,
+            logger.debug("on_drag: %s %s %d", shape.get_label(), handle,
                           self.selected.artist.get_zorder())
 
     def on_release(self, event):
         'on release we reset the press data'
-        logging.debug("on_release")
+        logger.debug("on_release")
         # display_artist_and_event('on_release', event, self.selected.artist)
 
         self.do_action(event, self.selected, 'release')

--- a/src/rayoptics/qtgui/pytablemodel.py
+++ b/src/rayoptics/qtgui/pytablemodel.py
@@ -14,6 +14,8 @@ from PyQt5.QtCore import pyqtSignal
 
 from rayoptics.util.misc_math import isanumber
 
+logger = logging.getLogger(__name__)
+
 
 class PyTableModel(QAbstractTableModel):
     """Table model supporting data content via python eval() fct.
@@ -137,7 +139,7 @@ class PyTableModel(QAbstractTableModel):
             except IndexError:
                 return False
             except SyntaxError:
-                logging.info('Syntax error: "%s"', value)
+                logger.info('Syntax error: "%s"', value)
                 return False
         else:
             return False

--- a/src/rayoptics/qtgui/rayopticsapp.py
+++ b/src/rayoptics/qtgui/rayopticsapp.py
@@ -37,6 +37,8 @@ from rayoptics.parax import firstorder
 from rayoptics.raytr import trace
 from rayoptics.raytr import traceerror as terr
 
+logger = logging.getLogger(__name__)
+
 
 class MainWindow(QMainWindow):
     count = 0
@@ -221,7 +223,7 @@ class MainWindow(QMainWindow):
                 title_bar = title_bar + opt_model.name()
             create_ipython_console(self, opt_model, title_bar, 800, 600)
         except MultipleInstanceError:
-            logging.debug("Unable to open iPython console. "
+            logger.debug("Unable to open iPython console. "
                           "MultipleInstanceError")
         except Exception as inst:
             print(type(inst))    # the exception instance
@@ -262,7 +264,7 @@ class MainWindow(QMainWindow):
                           "Zemax files (*.zmx)",
                           options=options)
             if fileName:
-                logging.debug("open file: %s", fileName)
+                logger.debug("open file: %s", fileName)
                 filename = Path(fileName)
                 self.cur_dir = filename.parent
                 self.open_file(filename)
@@ -277,7 +279,7 @@ class MainWindow(QMainWindow):
                           "Ray-Optics Files (*.roa);;All Files (*)",
                           options=options)
             if fileName:
-                logging.debug("save file: %s", fileName)
+                logger.debug("save file: %s", fileName)
                 self.save_file(fileName)
 
         if action == "Close":
@@ -524,7 +526,7 @@ class MainWindow(QMainWindow):
     def eventFilter(self, obj, event):
         """Used by subwindows in response to installEventFilter."""
         if (event.type() == QEvent.Close):
-            logging.debug(f"close event received: {obj}")
+            logger.debug(f"close event received: {obj}")
             self.delete_subwindow(obj)
         return False
 

--- a/src/rayoptics/seq/medium.py
+++ b/src/rayoptics/seq/medium.py
@@ -30,6 +30,8 @@ from opticalglass import opticalmedium as om
 from opticalglass import modelglass as mg
 from opticalglass import rindexinfo as rii
 
+logger = logging.getLogger(__name__)
+
 
 def glass_encode(n: float, v: float) -> str:
     return f'{int(1000*round((n - 1), 3)):3d}.{int(round(10*v, 3)):3d}'
@@ -58,7 +60,7 @@ def decode_medium(*inputs, **kwargs):
         cat = None
     mat = None
 
-    logging.debug(f"num inputs = {len(inputs)}, inputs[0] = {inputs[0]}, "
+    logger.debug(f"num inputs = {len(inputs)}, inputs[0] = {inputs[0]}, "
                   f"{type(inputs[0])}")
     if isanumber(inputs[0]):  # assume all args are numeric
         if len(inputs) <= 1:
@@ -96,17 +98,17 @@ def decode_medium(*inputs, **kwargs):
             try:
                 mat = gfact.create_glass(name, cat)
             except glasserror.GlassNotFoundError as gerr:
-                logging.info('%s glass data type %s not found',
+                logger.info('%s glass data type %s not found',
                              gerr.catalog,
                              gerr.name)
-                logging.info('Replacing material with air.')
+                logger.info('Replacing material with air.')
                 mat = om.Air()
     # glass instance args. if they respond to `rindex`, they're in
     elif hasattr(inputs[0], 'rindex'):
         mat = inputs[0]
 
     if mat:
-        logging.info(f"mat = {mat.name()}, {mat.catalog_name()}, {type(mat)}")
+        logger.info(f"mat = {mat.name()}, {mat.catalog_name()}, {type(mat)}")
     return mat
 
 

--- a/src/rayoptics/zemax/zmxread.py
+++ b/src/rayoptics/zemax/zmxread.py
@@ -27,6 +27,12 @@ from opticalglass import opticalmedium as om
 from opticalglass import glasserror
 from opticalglass import util
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+_fh = logging.FileHandler('zmx_read_lens.log', mode='w')
+_fh.setLevel(logging.INFO)
+logger.addHandler(_fh)
+
 _glass_handler = None
 _cmd_not_handled = None
 _track_contents = None
@@ -90,9 +96,6 @@ def read_lens(filename, inpt, **kwargs):
     global _glass_handler, _cmd_not_handled, _track_contents
     _cmd_not_handled = util.Counter()
     _track_contents = util.Counter()
-    logging.basicConfig(filename='zmx_read_lens.log',
-                        filemode='w',
-                        level=logging.INFO)
 
     # create an empty optical model; all surfaces will come from .zmx file
     opt_model = opticalmodel.OpticalModel(do_init=False)
@@ -208,7 +211,7 @@ def process_line(opt_model, line, line_no):
                  "TCMM", "FLOA", "PMAG", "TOTR", "SLAB",
                  "POPS", "COMM", "PZUP", "LANG", "FIMP", "COAT",
                  ):
-        logging.info('Line %d: Command %s not supported', line_no, cmd)
+        logger.info('Line %d: Command %s not supported', line_no, cmd)
     else:
         # don't recognize this cmd, record # of times encountered
         _cmd_not_handled[cmd] += 1
@@ -278,7 +281,7 @@ def post_process_input(opt_model, filename, **kwargs):
 
 
 def log_cmd(label, cmd, inputs):
-    logging.debug("%s: %s %s", label, cmd, str(inputs))
+    logger.debug("%s: %s %s", label, cmd, str(inputs))
 
 
 def handle_types_and_params(optm, cur, cmd, inputs):
@@ -369,7 +372,7 @@ def handle_types_and_params(optm, cur, cmd, inputs):
             elif i == 2:
                 normalizing_radius = param_val
                 if normalizing_radius != 1.0:
-                    logging.info('Normalizing radius not supported on extended surfaces')
+                    logger.info('Normalizing radius not supported on extended surfaces')
             elif i >= 3:
                 ifc.profile.coefs.append(param_val)
     else:
@@ -390,7 +393,7 @@ def handle_aperture_data(optm, cur, cmd, inputs):
         ca_val = float(items[0])
         if ca_val == 0.0:
             ca_val = 1.0
-            logging.info(f"Surf {cur}: zero value on DIAM input.")
+            logger.info(f"Surf {cur}: zero value on DIAM input.")
         ca_type = int(items[1])
         if hasattr(ifc, 'clear_apertures'):
             ca_list = ifc.clear_apertures


### PR DESCRIPTION
Hey, referring to #138 I have just replaced all the calls to the global `logging` module with local loggers. This way it should now be possible to change the logging level of all of these loggers externally with e.g.:
```python
logging.getLogger('rayoptics').setLevel(logging.ERROR)
```

In terms of logging, everything should have stayed the same, but I wasn't really able to run through all the things or run the GUI on my current setup. So it would be great if you could do a quick check beforehand to make sure everything is working as it should.

Cheers
Dominik Onyszkiewicz