### PR TITLE
Delay creation of log files until the first actual message to prevent creating empty files

### DIFF
--- a/src/rayoptics/codev/cmdproc.py
+++ b/src/rayoptics/codev/cmdproc.py
@@ -28,7 +28,7 @@ from opticalglass import modelglass as mg
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-_fh = logging.FileHandler('cv_cmd_proc.log', mode='w')
+_fh = logging.FileHandler('cv_cmd_proc.log', mode='w', delay=True)
 _fh.setLevel(logging.DEBUG)
 logger.addHandler(_fh)
 

--- a/src/rayoptics/zemax/zmxread.py
+++ b/src/rayoptics/zemax/zmxread.py
@@ -29,7 +29,7 @@ from opticalglass import util
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-_fh = logging.FileHandler('zmx_read_lens.log', mode='w')
+_fh = logging.FileHandler('zmx_read_lens.log', mode='w', delay=True)
 _fh.setLevel(logging.INFO)
 logger.addHandler(_fh)
 


### PR DESCRIPTION
Hey again, I've just realized that resulting from #143 the log files cv_cmd_proc.log and zmx_read_lens.log were always created independent of actually logging something into them because the `FileHandler` was initialized on module level and thus when importing any of the modules. These creations should now be delayed until logging to the file for the first time and thus solve that problem. 