### PR TITLE
Correct a typing mistake in waveabr.py

### DIFF
--- a/src/rayoptics/raytr/waveabr.py
+++ b/src/rayoptics/raytr/waveabr.py
@@ -469,7 +469,7 @@ def wave_abr_calc_inf_ref(fod, fld, wvl, foc, ray_pkg, chief_ray_pkg,
 
     n_img = abs(fod.n_img)
 
-    ta = ray[-1].p - image_pt
+    ta = ray[-1][mc.p] - image_pt
     numer = np.dot(d_cr_b4 - d_b4*np.dot(d_b4, d_cr_b4), ta)
     denom = 1 + np.dot(d_b4, d_cr_b4)
     W_inf = n_img * numer / denom


### PR DESCRIPTION
Dear Michael,

Thank you for constantly improving RayOptics.

I propose here a correction for a probable typing mistake. An error occurred when using analyses.trace_wavefront and analyses.focus_wavefront instead of analyses.eval_wavefront, in the case of an infinite reference sphere.