### PR TITLE
Correct material import in zmxread.py

### DIFF
--- a/src/rayoptics/zemax/zmxread.py
+++ b/src/rayoptics/zemax/zmxread.py
@@ -577,7 +577,7 @@ class ZmxGlassHandler(GlassHandlerBase):
                     self.track_contents['6 digit code'] += 1
                     return True
             else:  # must be a glass type
-                medium = self.find_glass(name, '')
+                medium = self.find_glass(name, self.glass_catalogs)
                 g.medium = medium
                 return True
 


### PR DESCRIPTION
Hello,

I propose this commit to use glass materials from the desired catalogs of the zemax file.
In fact, currently all catalogs are loaded, and so when some homonyms exist, they are not always loaded from the right manufacturer.