### PR TITLE
ZMX compatibility enhancements

### DIFF
--- a/src/rayoptics/raytr/wideangle.py
+++ b/src/rayoptics/raytr/wideangle.py
@@ -215,6 +215,8 @@ def find_real_enp_rev1(opm, stop_idx, fld, wvl, check_direction=True):
             z_enp = del_z/10
         trial += 1
 
+    if start_z is None or end_z is None:
+        return None, rr
     z_enp_a, ht_at_stop_a = start_z
     z_enp_b, ht_at_stop_b = end_z
     logger.debug(f"  start_z={z_enp_a:10.5f}  end_z={z_enp_b:10.5f}")
@@ -236,6 +238,8 @@ def find_real_enp_rev1(opm, stop_idx, fld, wvl, check_direction=True):
                 end_z = z_enp, ht_at_stop
             logger.debug(f"  sample point {z_enp=:8.4f}  ray passed: "
                          f"{rr.err is None}")
+        if start_z is None or end_z is None:
+            return None, rr
         a, b = start_z[0], end_z[0]
 
     # test for crossing between the end points
@@ -303,8 +307,11 @@ def find_real_enp_rev1(opm, stop_idx, fld, wvl, check_direction=True):
     logger.debug(f"  ht_at_stop: start_z={start_z[1]:10.5f} "
                  f"end_z={end_z[1]:10.5f}")
 
-    start_coords, rr, results = find_z_enp_on_interval(opm, stop_idx, a, b, 
+    try:
+        start_coords, rr, results = find_z_enp_on_interval(opm, stop_idx, a, b, 
                                                        z_estimate, fld, wvl)
+    except (IndexError, ValueError):
+        return None, rr
     z_enp = start_coords[2]
 
     final_coord = rr.pkg.ray[stop_idx][mc.p]

--- a/src/rayoptics/zemax/zmxread.py
+++ b/src/rayoptics/zemax/zmxread.py
@@ -300,7 +300,7 @@ def handle_types_and_params(optm, cur, cmd, inputs):
         # useful to remember the Type of Zemax surface
         ifc.z_type = typ
         _track_contents[typ] += 1
-        if typ == 'EVENASPH' or typ == 'XASPHERE':
+        if typ == 'EVENASPH':
             cur_profile = ifc.profile
             new_profile = profiles.mutate_profile(cur_profile,
                                                   'EvenPolynomial')
@@ -310,7 +310,7 @@ def handle_types_and_params(optm, cur, cmd, inputs):
             new_profile = profiles.mutate_profile(cur_profile,
                                                   'YToroid')
             ifc.profile = new_profile
-        elif typ == 'XOSPHERE':
+        elif typ == 'XOSPHERE' or typ == 'XASPHERE':
             cur_profile = ifc.profile
             new_profile = profiles.mutate_profile(cur_profile,
                                                   'RadialPolynomial')
@@ -358,8 +358,12 @@ def handle_types_and_params(optm, cur, cmd, inputs):
                 ifc.phase_element.grating_freq_um = param_val
             elif i == 2:
                 ifc.phase_element.order = param_val
-        elif ifc.z_type == 'EVENASPH' or ifc.z_type == 'XASPHERE':
+        elif ifc.z_type == 'EVENASPH':
             ifc.profile.coefs[i-1] = param_val
+        elif ifc.z_type == 'XASPHERE':
+            if i * 2 > len(ifc.profile.coefs):
+                ifc.profile.coefs.extend([0.0] * (i * 2 - len(ifc.profile.coefs)))
+            ifc.profile.coefs[i * 2 - 1] = param_val
         elif ifc.z_type == 'PARAXIAL':
             if i == 1:
                 ifc.optical_power = 1/param_val
@@ -373,7 +377,7 @@ def handle_types_and_params(optm, cur, cmd, inputs):
         inputs = inputs.split()
         i = int(inputs[0])
         param_val = float(inputs[1])
-        if ifc.z_type == 'XOSPHERE':
+        if ifc.z_type == 'XOSPHERE' or ifc.z_type == 'XASPHERE':
             if i == 1:
                 num_terms = param_val
                 ifc.profile.coefs = []

--- a/src/rayoptics/zemax/zmxread.py
+++ b/src/rayoptics/zemax/zmxread.py
@@ -300,7 +300,7 @@ def handle_types_and_params(optm, cur, cmd, inputs):
         # useful to remember the Type of Zemax surface
         ifc.z_type = typ
         _track_contents[typ] += 1
-        if typ == 'EVENASPH':
+        if typ == 'EVENASPH' or typ == 'XASPHERE':
             cur_profile = ifc.profile
             new_profile = profiles.mutate_profile(cur_profile,
                                                   'EvenPolynomial')
@@ -358,7 +358,7 @@ def handle_types_and_params(optm, cur, cmd, inputs):
                 ifc.phase_element.grating_freq_um = param_val
             elif i == 2:
                 ifc.phase_element.order = param_val
-        elif ifc.z_type == 'EVENASPH':
+        elif ifc.z_type == 'EVENASPH' or ifc.z_type == 'XASPHERE':
             ifc.profile.coefs[i-1] = param_val
         elif ifc.z_type == 'PARAXIAL':
             if i == 1:

--- a/src/rayoptics/zemax/zmxread.py
+++ b/src/rayoptics/zemax/zmxread.py
@@ -589,8 +589,20 @@ class ZmxGlassHandler(GlassHandlerBase):
                     self.track_contents['6 digit code'] += 1
                     return True
             else:  # must be a glass type
-                medium = self.find_glass(name, self.glass_catalogs)
-                g.medium = medium
+                medium = self.find_glass(name, self.glass_catalogs, always=False)
+                if medium is None:
+                    nd = float(inputs[3])
+                    vd = float(inputs[4])
+                    if vd == 0:
+                        if nd == 0:
+                            g.medium = om.ConstantIndex(1.5, 'not '+name)
+                        else:
+                            # Zemax treats Vd=0 as constant index
+                            g.medium = om.ConstantIndex(nd, f"n:{nd:.3f}")
+                    else:
+                        g.medium = mg.ModelGlass(nd, vd, om.glass_encode(nd, vd))
+                else:
+                    g.medium = medium
                 return True
 
         else:


### PR DESCRIPTION
1. I've seen ZMX files with XASPHERE surfaces that are either XOSPHERE or EVENASPH. Even though I suspect the latter is exported from non-compliant software, both styles are supported.
2. If a glass specified in a zmx file is not found, then as a fallback, the refractive index and Abbe number may immediately follow the same GLAS command.
3. When a field is totally vignetted because it is completely outside of the lens' image circle, exceptions may be raised. The objective is to fix those exceptions in order to preserve the fields which pass through.